### PR TITLE
minor changes & support json encode

### DIFF
--- a/authorizerd.go
+++ b/authorizerd.go
@@ -275,7 +275,7 @@ func (a *authorizer) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certi
 	}
 
 	if len(domainRoles) == 0 {
-		return errors.New("not valid role certificate")
+		return errors.New("invalid role certificate")
 	}
 
 	var err error

--- a/authorizerd.go
+++ b/authorizerd.go
@@ -246,7 +246,7 @@ func (a *authorizer) verify(ctx context.Context, m mode, tok, act, res string) e
 
 	if err := a.policyd.CheckPolicy(ctx, domain, roles, act, res); err != nil {
 		glg.Debugf("error check, err: %v", err)
-		return errors.Wrap(err, "token unauthorizate")
+		return errors.Wrap(err, "token unauthorized")
 	}
 	glg.Debugf("set roletoken result. tok: %s, act: %s, res: %s", tok, act, res)
 	a.cache.SetWithExpire(tok+act+res, struct{}{}, a.cacheExp)
@@ -286,7 +286,7 @@ func (a *authorizer) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certi
 		}
 	}
 
-	return errors.Wrap(err, "role certificates unauthorizate")
+	return errors.Wrap(err, "role certificates unauthorized")
 }
 
 func (a *authorizer) GetPolicyCache(ctx context.Context) map[string]interface{} {

--- a/authorizerd.go
+++ b/authorizerd.go
@@ -155,21 +155,21 @@ func New(opts ...Option) (Authorizerd, error) {
 }
 
 // Start starts authorizer daemon.
-func (p *authorizer) Start(ctx context.Context) <-chan error {
+func (a *authorizer) Start(ctx context.Context) <-chan error {
 	var (
 		ech              = make(chan error, 200)
-		g                = p.cache.StartExpired(ctx, p.cacheExp/2)
+		g                = a.cache.StartExpired(ctx, a.cacheExp/2)
 		cech, pech, jech <-chan error
 	)
 
-	if !p.disablePubkeyd {
-		cech = p.pubkeyd.Start(ctx)
+	if !a.disablePubkeyd {
+		cech = a.pubkeyd.Start(ctx)
 	}
-	if !p.disablePolicyd {
-		pech = p.policyd.Start(ctx)
+	if !a.disablePolicyd {
+		pech = a.policyd.Start(ctx)
 	}
-	if !p.disableJwkd {
-		jech = p.jwkd.Start(ctx)
+	if !a.disableJwkd {
+		jech = a.jwkd.Start(ctx)
 	}
 
 	go func() {
@@ -200,21 +200,21 @@ func (p *authorizer) Start(ctx context.Context) <-chan error {
 }
 
 // VerifyRoleToken verifies the role token for specific resource and return and verification error.
-func (p *authorizer) VerifyRoleToken(ctx context.Context, tok, act, res string) error {
-	return p.verify(ctx, token, tok, act, res)
+func (a *authorizer) VerifyRoleToken(ctx context.Context, tok, act, res string) error {
+	return a.verify(ctx, token, tok, act, res)
 }
 
-func (p *authorizer) VerifyRoleJWT(ctx context.Context, tok, act, res string) error {
-	return p.verify(ctx, jwt, tok, act, res)
+func (a *authorizer) VerifyRoleJWT(ctx context.Context, tok, act, res string) error {
+	return a.verify(ctx, jwt, tok, act, res)
 }
 
-func (p *authorizer) verify(ctx context.Context, m mode, tok, act, res string) error {
+func (a *authorizer) verify(ctx context.Context, m mode, tok, act, res string) error {
 	if act == "" || res == "" {
 		return errors.Wrap(ErrInvalidParameters, "empty action / resource")
 	}
 
 	// check if exists in verification success cache
-	_, ok := p.cache.Get(tok + act + res)
+	_, ok := a.cache.Get(tok + act + res)
 	if ok {
 		glg.Debugf("use cached result. tok: %s, act: %s, res: %s", tok, act, res)
 		return nil
@@ -227,7 +227,7 @@ func (p *authorizer) verify(ctx context.Context, m mode, tok, act, res string) e
 
 	switch m {
 	case token:
-		rt, err := p.roleProcessor.ParseAndValidateRoleToken(tok)
+		rt, err := a.roleProcessor.ParseAndValidateRoleToken(tok)
 		if err != nil {
 			glg.Debugf("error parse and validate role token, err: %v", err)
 			return errors.Wrap(err, "error verify role token")
@@ -235,7 +235,7 @@ func (p *authorizer) verify(ctx context.Context, m mode, tok, act, res string) e
 		domain = rt.Domain
 		roles = rt.Roles
 	case jwt:
-		rc, err := p.roleProcessor.ParseAndValidateRoleJWT(tok)
+		rc, err := a.roleProcessor.ParseAndValidateRoleJWT(tok)
 		if err != nil {
 			glg.Debugf("error parse and validate role jwt, err: %v", err)
 			return errors.Wrap(err, "error verify role jwt")
@@ -244,23 +244,23 @@ func (p *authorizer) verify(ctx context.Context, m mode, tok, act, res string) e
 		roles = strings.Split(strings.TrimSpace(rc.Role), ",")
 	}
 
-	if err := p.policyd.CheckPolicy(ctx, domain, roles, act, res); err != nil {
+	if err := a.policyd.CheckPolicy(ctx, domain, roles, act, res); err != nil {
 		glg.Debugf("error check, err: %v", err)
 		return errors.Wrap(err, "token unauthorizate")
 	}
 	glg.Debugf("set roletoken result. tok: %s, act: %s, res: %s", tok, act, res)
-	p.cache.SetWithExpire(tok+act+res, struct{}{}, p.cacheExp)
+	a.cache.SetWithExpire(tok+act+res, struct{}{}, a.cacheExp)
 	return nil
 }
 
-func (p *authorizer) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certificate, act, res string) error {
+func (a *authorizer) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certificate, act, res string) error {
 	dr := make([]string, 0, 2)
 	drcheck := make(map[string]struct{})
 	domainRoles := make(map[string][]string)
 	for _, cert := range peerCerts {
 		for _, uri := range cert.URIs {
-			if strings.HasPrefix(uri.String(), p.roleCertURIPrefix) {
-				dr = strings.SplitN(strings.TrimPrefix(uri.String(), p.roleCertURIPrefix), "/", 2) // domain/role
+			if strings.HasPrefix(uri.String(), a.roleCertURIPrefix) {
+				dr = strings.SplitN(strings.TrimPrefix(uri.String(), a.roleCertURIPrefix), "/", 2) // domain/role
 				if len(dr) != 2 {
 					continue
 				}
@@ -281,7 +281,7 @@ func (p *authorizer) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certi
 	var err error
 	for domain, roles := range domainRoles {
 		// TODO futurework
-		if err = p.policyd.CheckPolicy(ctx, domain, roles, act, res); err == nil {
+		if err = a.policyd.CheckPolicy(ctx, domain, roles, act, res); err == nil {
 			return nil
 		}
 	}
@@ -289,7 +289,7 @@ func (p *authorizer) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certi
 	return errors.Wrap(err, "role certificates unauthorizate")
 }
 
-func (p *authorizer) GetPolicyCache(ctx context.Context) map[string]interface{} {
-	return p.policyd.GetPolicyCache(ctx)
+func (a *authorizer) GetPolicyCache(ctx context.Context) map[string]interface{} {
+	return a.policyd.GetPolicyCache(ctx)
 
 }

--- a/authorizerd_test.go
+++ b/authorizerd_test.go
@@ -844,8 +844,7 @@ ei9zYS9zeW5jZXKGHmF0aGVuejovL3JvbGUvY29yZXRlY2gvcmVhZGVyc4YeYXRo
 ZW56Oi8vcm9sZS9jb3JldGVjaC93cml0ZXJzMA0GCSqGSIb3DQEBCwUAA0EAa3Ra
 Wo7tEDFBGqSVYSVuoh0GpsWC0VBAYYi9vhAGfp+g5M2oszvRuxOHYsQmYAjYroTJ
 bu80CwTnWhmdBo36Ig==
------END CERTIFICATE-----
-`
+-----END CERTIFICATE-----`
 			block, _ := pem.Decode([]byte(crt))
 			cert, _ := x509.ParseCertificate(block.Bytes)
 
@@ -941,8 +940,7 @@ ei9zYS9zeW5jZXKGHmF0aGVuejovL3JvbGUvY29yZXRlY2gvcmVhZGVyc4YeYXRo
 ZW56Oi8vcm9sZS9jb3JldGVjaC93cml0ZXJzMA0GCSqGSIb3DQEBCwUAA0EAa3Ra
 Wo7tEDFBGqSVYSVuoh0GpsWC0VBAYYi9vhAGfp+g5M2oszvRuxOHYsQmYAjYroTJ
 bu80CwTnWhmdBo36Ig==
------END CERTIFICATE-----
-`
+-----END CERTIFICATE-----`
 			block, _ := pem.Decode([]byte(crt))
 			cert, _ := x509.ParseCertificate(block.Bytes)
 

--- a/authorizerd_test.go
+++ b/authorizerd_test.go
@@ -113,7 +113,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestStart(t *testing.T) {
+func Test_authorizer_Start(t *testing.T) {
 	type fields struct {
 		pubkeyd  pubkey.Daemon
 		policyd  policy.Daemon
@@ -289,7 +289,7 @@ func TestStart(t *testing.T) {
 	}
 }
 
-func TestVerifyRoleToken(t *testing.T) {
+func Test_authorizer_VerifyRoleToken(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		tok string

--- a/authorizerd_test.go
+++ b/authorizerd_test.go
@@ -463,7 +463,7 @@ func TestVerifyRoleToken(t *testing.T) {
 					cache:              c,
 					cacheExp:           time.Minute,
 				},
-				wantErr: "token unauthorizate: deny",
+				wantErr: "token unauthorized: deny",
 			}
 		}(),
 	}
@@ -684,7 +684,7 @@ func Test_authorizer_VerifyRoleJWT(t *testing.T) {
 					cache:         c,
 					cacheExp:      time.Minute,
 				},
-				wantErr: "token unauthorizate: deny",
+				wantErr: "token unauthorized: deny",
 			}
 		}(),
 	}

--- a/authorizerd_test.go
+++ b/authorizerd_test.go
@@ -910,7 +910,7 @@ KSdPh6TRd/kYpv7t6cVm1Orll4O5jh+IdoguGkOCxheMaQ==
 			}
 
 			return test{
-				name: "invalid athenz role certificate",
+				name: "invalid athenz role certificate, invalid SAN",
 				fields: fields{
 					roleCertURIPrefix: "athenz://role/",
 					policyd:           pm,
@@ -951,7 +951,7 @@ bu80CwTnWhmdBo36Ig==
 			}
 
 			return test{
-				name: "parse and verify role cert success",
+				name: "invalid athenz role certificate, deny by policyd",
 				fields: fields{
 					roleCertURIPrefix: "athenz://role/",
 					policyd:           pm,

--- a/errors.go
+++ b/errors.go
@@ -36,7 +36,7 @@ var (
 	ErrDomainExpired = policy.ErrDomainExpired
 	// ErrNoMatch "Access denied due to no match to any of the assertions defined in domain policy file"
 	ErrNoMatch = policy.ErrNoMatch
-	// ErrInvalidPolicyResource "Access denied due to invalie/empty policy resources"
+	// ErrInvalidPolicyResource "Access denied due to invalid/empty policy resources"
 	ErrInvalidPolicyResource = policy.ErrInvalidPolicyResource
 	// ErrDenyByPolicy "Access Check was explicitly denied"
 	ErrDenyByPolicy = policy.ErrDenyByPolicy

--- a/jwk/daemon.go
+++ b/jwk/daemon.go
@@ -78,12 +78,15 @@ func (j *jwkd) Start(ctx context.Context) <-chan error {
 		update := func() {
 			if err := j.Update(ctx); err != nil {
 				err = errors.Wrap(err, "error update athenz json web key")
+				time.Sleep(j.errRetryInterval)
+
 				select {
 				case ech <- errors.Wrap(ebuf, err.Error()):
 					ebuf = errors.New("")
 				default:
 					ebuf = errors.Wrap(ebuf, err.Error())
 				}
+
 				select {
 				case fch <- struct{}{}:
 				default:

--- a/jwk/daemon_test.go
+++ b/jwk/daemon_test.go
@@ -177,8 +177,8 @@ func Test_jwkd_Start(t *testing.T) {
 						return errors.New("cannot update keys")
 					}
 
-					if k1 == k2 {
-						return errors.Errorf("key do not update after it starts, k1: %s, k2: %s", k1, k2)
+					if k1.(*jwk.Set).Keys[0].KeyID() == k2.(*jwk.Set).Keys[0].KeyID() {
+						return errors.Errorf("key do not update after it starts, k1.KeyID: %v equals k2.KeyID: %v", k1.(*jwk.Set).Keys[0].KeyID(), k2.(*jwk.Set).Keys[0].KeyID())
 					}
 
 					return nil

--- a/jwk/daemon_test.go
+++ b/jwk/daemon_test.go
@@ -101,9 +101,9 @@ func Test_jwkd_Start(t *testing.T) {
 	tests := []test{
 		func() test {
 			k := `{
-      "e":"AQAB",
-      "kty":"RSA",
-      "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+"e":"AQAB",
+"kty":"RSA",
+"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 		}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
@@ -139,10 +139,10 @@ func Test_jwkd_Start(t *testing.T) {
 		func() test {
 			i := 1
 			k := `{
-      "e":"AQAB",
-      "kty":"RSA",
-	  "kid" :"%s",
-      "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+"e":"AQAB",
+"kty":"RSA",
+"kid" :"%s",
+"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 		}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
@@ -191,9 +191,9 @@ func Test_jwkd_Start(t *testing.T) {
 		func() test {
 			i := 1
 			k := `{
-      "e":"AQAB",
-      "kty":"RSA",
-      "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+"e":"AQAB",
+"kty":"RSA",
+"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 		}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if i < 3 {
@@ -276,9 +276,9 @@ func Test_jwkd_Update(t *testing.T) {
 	tests := []test{
 		func() test {
 			k := `{
-      "e":"AQAB",
-      "kty":"RSA",
-      "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+"e":"AQAB",
+"kty":"RSA",
+"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 		}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
@@ -310,9 +310,9 @@ func Test_jwkd_Update(t *testing.T) {
 		}(),
 		func() test {
 			k := `{
-      "e":"AQAB",
-      "kty":"dummy",
-      "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+"e":"AQAB",
+"kty":"dummy",
+"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 		}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)

--- a/jwk/daemon_test.go
+++ b/jwk/daemon_test.go
@@ -52,7 +52,7 @@ func TestNew(t *testing.T) {
 			want: &jwkd{
 				athenzURL:        "www.dummy.com",
 				refreshDuration:  time.Hour * 24,
-				errRetryInterval: time.Millisecond,
+				errRetryInterval: time.Minute,
 				client:           http.DefaultClient,
 			},
 		},

--- a/jwk/daemon_test.go
+++ b/jwk/daemon_test.go
@@ -104,7 +104,7 @@ func Test_jwkd_Start(t *testing.T) {
 "e":"AQAB",
 "kty":"RSA",
 "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
-		}`
+}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
 				w.Write([]byte(k))
@@ -143,7 +143,7 @@ func Test_jwkd_Start(t *testing.T) {
 "kty":"RSA",
 "kid" :"%s",
 "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
-		}`
+}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
 				w.Write([]byte(fmt.Sprintf(k, i)))
@@ -194,7 +194,7 @@ func Test_jwkd_Start(t *testing.T) {
 "e":"AQAB",
 "kty":"RSA",
 "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
-		}`
+}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if i < 3 {
 					i++
@@ -279,7 +279,7 @@ func Test_jwkd_Update(t *testing.T) {
 "e":"AQAB",
 "kty":"RSA",
 "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
-		}`
+}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
 				w.Write([]byte(k))
@@ -313,7 +313,7 @@ func Test_jwkd_Update(t *testing.T) {
 "e":"AQAB",
 "kty":"dummy",
 "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
-		}`
+}`
 			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
 				w.Write([]byte(k))

--- a/jwk/option.go
+++ b/jwk/option.go
@@ -25,7 +25,7 @@ import (
 var (
 	defaultOptions = []Option{
 		WithRefreshDuration("24h"),
-		WithErrRetryInterval("1ms"),
+		WithErrRetryInterval("1m"),
 		WithHTTPClient(http.DefaultClient),
 	}
 )

--- a/option.go
+++ b/option.go
@@ -35,7 +35,7 @@ var (
 // Option represents a functional options pattern interface
 type Option func(*authorizer) error
 
-// AthenzURL represents a AthenzURL functional option
+// WithAthenzURL represents a AthenzURL functional option
 func WithAthenzURL(url string) Option {
 	return func(prov *authorizer) error {
 		prov.athenzURL = url

--- a/option_test.go
+++ b/option_test.go
@@ -459,7 +459,7 @@ func TestWithPolicyEtagFlushDuration(t *testing.T) {
 		})
 	}
 }
-func TestPolicyEtagExpTime(t *testing.T) {
+func TestWithPolicyEtagExpTime(t *testing.T) {
 	type args struct {
 		t string
 	}
@@ -494,7 +494,7 @@ func TestPolicyEtagExpTime(t *testing.T) {
 		})
 	}
 }
-func TestCacheExp(t *testing.T) {
+func TestWithCacheExp(t *testing.T) {
 	type args struct {
 		d time.Duration
 	}
@@ -531,7 +531,7 @@ func TestCacheExp(t *testing.T) {
 		})
 	}
 }
-func TestTransport(t *testing.T) {
+func TestWithTransport(t *testing.T) {
 	type args struct {
 		t *http.Transport
 	}

--- a/policy/assertion.go
+++ b/policy/assertion.go
@@ -41,7 +41,7 @@ type Assertion struct {
 func NewAssertion(action, resource, effect string) (*Assertion, error) {
 	domres := strings.SplitN(resource, ":", 2)
 	if len(domres) < 2 {
-		return nil, errors.Wrap(ErrInvalidPolicyResource, "assestion format not correct")
+		return nil, errors.Wrap(ErrInvalidPolicyResource, "assertion format not correct")
 	}
 	dom := domres[0]
 	res := domres[1]
@@ -49,7 +49,7 @@ func NewAssertion(action, resource, effect string) (*Assertion, error) {
 	regexStr := "^" + replacer.Replace(strings.ToLower(action+"-"+res)) + "$"
 	reg, err := regexp.Compile(regexStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "assestion format not correct")
+		return nil, errors.Wrap(err, "assertion format not correct")
 	}
 
 	return &Assertion{

--- a/policy/assertion.go
+++ b/policy/assertion.go
@@ -28,8 +28,12 @@ var (
 
 // Assertion represents the refined assertion data use in policy checking
 type Assertion struct {
-	Reg            *regexp.Regexp
+	Action      string
+	Resource    string
+	RegexString string
+
 	ResourceDomain string
+	Reg            *regexp.Regexp `json:"-"`
 	Effect         error
 }
 
@@ -39,14 +43,20 @@ func NewAssertion(action, resource, effect string) (*Assertion, error) {
 	if len(domres) < 2 {
 		return nil, errors.Wrap(ErrInvalidPolicyResource, "assestion format not correct")
 	}
+	dom := domres[0]
+	res := domres[1]
 
-	reg, err := regexp.Compile("^" + replacer.Replace(strings.ToLower(action+"-"+domres[1])) + "$")
+	regexStr := "^" + replacer.Replace(strings.ToLower(action+"-"+res)) + "$"
+	reg, err := regexp.Compile(regexStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "assestion format not correct")
 	}
 
 	return &Assertion{
-		ResourceDomain: domres[0],
+		Action:         action,
+		Resource:       res,
+		RegexString:    regexStr,
+		ResourceDomain: dom,
 		Reg:            reg,
 		Effect: func() error {
 			if strings.EqualFold("deny", effect) {

--- a/policy/assertion.go
+++ b/policy/assertion.go
@@ -28,9 +28,8 @@ var (
 
 // Assertion represents the refined assertion data use in policy checking
 type Assertion struct {
-	Action      string
-	Resource    string
-	RegexString string
+	Action   string
+	Resource string
 
 	ResourceDomain string
 	Reg            *regexp.Regexp `json:"-"`
@@ -55,7 +54,6 @@ func NewAssertion(action, resource, effect string) (*Assertion, error) {
 	return &Assertion{
 		Action:         action,
 		Resource:       res,
-		RegexString:    regexStr,
 		ResourceDomain: dom,
 		Reg:            reg,
 		Effect: func() error {

--- a/policy/assertion.go
+++ b/policy/assertion.go
@@ -82,7 +82,7 @@ func (a *Assertion) MarshalJSON() ([]byte, error) {
 		Resource:       a.Resource,
 		ResourceDomain: a.ResourceDomain,
 		Reg:            a.Reg.String(),
-		Deny:           a.Effect == nil,
+		Deny:           a.Effect != nil,
 	}
 	return json.Marshal(x)
 }

--- a/policy/assertion.go
+++ b/policy/assertion.go
@@ -16,6 +16,7 @@ limitations under the License.
 package policy
 
 import (
+	"encoding/json"
 	"regexp"
 	"strings"
 
@@ -32,7 +33,7 @@ type Assertion struct {
 	Resource string
 
 	ResourceDomain string
-	Reg            *regexp.Regexp `json:"-"`
+	Reg            *regexp.Regexp
 	Effect         error
 }
 
@@ -63,4 +64,25 @@ func NewAssertion(action, resource, effect string) (*Assertion, error) {
 			return nil
 		}(),
 	}, nil
+}
+
+// AssertionJSON represents json format of Assertion
+type AssertionJSON struct {
+	Action         string `json:"action"`
+	Resource       string `json:"resource"`
+	ResourceDomain string `json:"domain"`
+	Reg            string `json:"reg"`
+	Deny           bool   `json:"deny"`
+}
+
+// MarshalJSON implements the Marshaler interface.
+func (a *Assertion) MarshalJSON() ([]byte, error) {
+	x := &AssertionJSON{
+		Action:         a.Action,
+		Resource:       a.Resource,
+		ResourceDomain: a.ResourceDomain,
+		Reg:            a.Reg.String(),
+		Deny:           a.Effect == nil,
+	}
+	return json.Marshal(x)
 }

--- a/policy/assertion_test.go
+++ b/policy/assertion_test.go
@@ -143,7 +143,7 @@ func TestAssertion_MarshalJSON(t *testing.T) {
 				action:   "act",
 				effect:   "allow",
 			},
-			want: `{"action":"act","resource":"res","domain":"dom","reg":"^act-res$","deny":true}` + "\n",
+			want: `{"action":"act","resource":"res","domain":"dom","reg":"^act-res$","deny":false}` + "\n",
 		},
 		{
 			name: "encoding JSON: deny policy",
@@ -152,7 +152,7 @@ func TestAssertion_MarshalJSON(t *testing.T) {
 				action:   "act",
 				effect:   "deny",
 			},
-			want: `{"action":"act","resource":"res","domain":"dom","reg":"^act-res$","deny":false}` + "\n",
+			want: `{"action":"act","resource":"res","domain":"dom","reg":"^act-res$","deny":true}` + "\n",
 		},
 	}
 	for _, tt := range tests {

--- a/policy/assertion_test.go
+++ b/policy/assertion_test.go
@@ -47,7 +47,6 @@ func TestNewAssertion(t *testing.T) {
 			want: &Assertion{
 				Action:         "act",
 				Resource:       "res",
-				RegexString:    "^act-res$",
 				ResourceDomain: "dom",
 				Reg: func() *regexp.Regexp {
 					r, _ := regexp.Compile("^act-res$")
@@ -73,7 +72,6 @@ func TestNewAssertion(t *testing.T) {
 			want: &Assertion{
 				Action:         "act",
 				Resource:       "res",
-				RegexString:    "^act-res$",
 				ResourceDomain: "dom",
 				Reg: func() *regexp.Regexp {
 					r, _ := regexp.Compile("^act-res$")

--- a/policy/assertion_test.go
+++ b/policy/assertion_test.go
@@ -98,7 +98,7 @@ func TestNewAssertion(t *testing.T) {
 				action:   "act",
 				effect:   "deny",
 			},
-			wantErr: errors.New("assestion format not correct: Access denied due to invalid/empty policy resources"),
+			wantErr: errors.New("assertion format not correct: Access denied due to invalid/empty policy resources"),
 		},
 	}
 	for _, tt := range tests {

--- a/policy/assertion_test.go
+++ b/policy/assertion_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 package policy
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -54,7 +52,8 @@ func TestNewAssertion(t *testing.T) {
 					r, _ := regexp.Compile("^act-res$")
 					return r
 				}(),
-				Effect: nil,
+				Effect:      nil,
+				RegexString: "^act-res$",
 			},
 			checkFunc: func(got, want *Assertion) error {
 				if !reflect.DeepEqual(got, want) {
@@ -79,7 +78,8 @@ func TestNewAssertion(t *testing.T) {
 					r, _ := regexp.Compile("^act-res$")
 					return r
 				}(),
-				Effect: errors.New("policy deny: Access Check was explicitly denied"),
+				Effect:      errors.New("policy deny: Access Check was explicitly denied"),
+				RegexString: "^act-res$",
 			},
 			checkFunc: func(got, want *Assertion) error {
 				if got.ResourceDomain != want.ResourceDomain ||
@@ -118,62 +118,6 @@ func TestNewAssertion(t *testing.T) {
 					t.Errorf("NewAssertion error = %v, wantErr %v", err, tt.wantErr)
 				} else if err.Error() != tt.wantErr.Error() {
 					t.Errorf("NewAssertion error = %v, wantErr %v", err, tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
-func TestAssertion_MarshalJSON(t *testing.T) {
-	type args struct {
-		action   string
-		resource string
-		effect   string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr error
-	}{
-		{
-			name: "encoding JSON: allow policy",
-			args: args{
-				resource: "dom:res",
-				action:   "act",
-				effect:   "allow",
-			},
-			want: `{"action":"act","resource":"res","domain":"dom","reg":"^act-res$","deny":false}` + "\n",
-		},
-		{
-			name: "encoding JSON: deny policy",
-			args: args{
-				resource: "dom:res",
-				action:   "act",
-				effect:   "deny",
-			},
-			want: `{"action":"act","resource":"res","domain":"dom","reg":"^act-res$","deny":true}` + "\n",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewAssertion(tt.args.action, tt.args.resource, tt.args.effect)
-
-			b := bytes.NewBuffer(make([]byte, 0))
-			err = json.NewEncoder(b).Encode(got)
-
-			if b.String() != tt.want {
-				t.Errorf("Assertion.MarshalJSON error: %v != %v", b.String(), tt.want)
-			}
-			if err == nil {
-				if tt.wantErr != nil {
-					t.Errorf("Assertion.MarshalJSON = %v, wantErr %v", err, tt.wantErr)
-				}
-			} else {
-				if tt.wantErr == nil {
-					t.Errorf("Assertion.MarshalJSON error = %v, wantErr %v", err, tt.wantErr)
-				} else if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Assertion.MarshalJSON error = %v, wantErr %v", err, tt.wantErr)
 				}
 			}
 		})

--- a/policy/assertion_test.go
+++ b/policy/assertion_test.go
@@ -45,6 +45,9 @@ func TestNewAssertion(t *testing.T) {
 				effect:   "allow",
 			},
 			want: &Assertion{
+				Action:         "act",
+				Resource:       "res",
+				RegexString:    "^act-res$",
 				ResourceDomain: "dom",
 				Reg: func() *regexp.Regexp {
 					r, _ := regexp.Compile("^act-res$")
@@ -68,6 +71,9 @@ func TestNewAssertion(t *testing.T) {
 				effect:   "deny",
 			},
 			want: &Assertion{
+				Action:         "act",
+				Resource:       "res",
+				RegexString:    "^act-res$",
 				ResourceDomain: "dom",
 				Reg: func() *regexp.Regexp {
 					r, _ := regexp.Compile("^act-res$")

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -2153,9 +2153,8 @@ func Test_policyd_GetPolicyCache(t *testing.T) {
 			fields: fields{
 				rolePolicies: func() gache.Gache {
 					g := gache.New()
-					g.SetWithExpire("key", "value", time.Duration(1)*time.Nanosecond)
-					// time.Sleep(time.Duration(2) * time.Nanosecond) // not working
-					time.Sleep(time.Duration(2) * time.Millisecond)
+					g.SetWithExpire("key", "value", 1*time.Nanosecond)
+					time.Sleep(100 * time.Nanosecond)
 					g.DeleteExpired(context.Background())
 					return g
 				}(),
@@ -2183,7 +2182,7 @@ func Test_policyd_GetPolicyCache(t *testing.T) {
 				client:                tt.fields.client,
 			}
 			if got := p.GetPolicyCache(tt.args.ctx); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("policyd.GetPolicyCache() = %v, want %v", got, tt.want)
+				t.Errorf("policyd.GetPolicyCache() = %+v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -96,7 +96,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func Test_policy_Start(t *testing.T) {
+func Test_policyd_Start(t *testing.T) {
 	type fields struct {
 		expireMargin          time.Duration
 		rolePolicies          gache.Gache
@@ -352,7 +352,7 @@ func Test_policy_Start(t *testing.T) {
 	}
 }
 
-func Test_policy_Update(t *testing.T) {
+func Test_policyd_Update(t *testing.T) {
 	type fields struct {
 		expireMargin          time.Duration
 		rolePolicies          gache.Gache
@@ -553,7 +553,7 @@ func Test_policy_Update(t *testing.T) {
 	}
 }
 
-func Test_policy_CheckPolicy(t *testing.T) {
+func Test_policyd_CheckPolicy(t *testing.T) {
 	type fields struct {
 		expireMargin     time.Duration
 		rolePolicies     gache.Gache
@@ -768,7 +768,7 @@ func Test_policy_CheckPolicy(t *testing.T) {
 	}
 }
 
-func Test_policy_fetchAndCachePolicy(t *testing.T) {
+func Test_policyd_fetchAndCachePolicy(t *testing.T) {
 	type fields struct {
 		expireMargin          time.Duration
 		rolePolicies          gache.Gache
@@ -932,7 +932,7 @@ func Test_policy_fetchAndCachePolicy(t *testing.T) {
 	}
 }
 
-func Test_policy_fetchPolicy(t *testing.T) {
+func Test_policyd_fetchPolicy(t *testing.T) {
 	type fields struct {
 		expireMargin          time.Duration
 		rolePolicies          gache.Gache
@@ -1415,7 +1415,7 @@ func Test_policy_fetchPolicy(t *testing.T) {
 	}
 }
 
-func Test_policy_simplifyAndCache(t *testing.T) {
+func Test_policyd_simplifyAndCache(t *testing.T) {
 	type fields struct {
 		expireMargin          time.Duration
 		rolePolicies          gache.Gache

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -2120,10 +2120,43 @@ func Test_policyd_GetPolicyCache(t *testing.T) {
 		want   map[string]interface{}
 	}{
 		{
+			name: "get empty policy cache success",
+			fields: fields{
+				rolePolicies: func() gache.Gache {
+					g := gache.New()
+					return g
+				}(),
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: make(map[string]interface{}),
+		},
+		{
 			name: "get policy cache success",
 			fields: fields{
 				rolePolicies: func() gache.Gache {
 					g := gache.New()
+					g.Set("key", "value")
+					return g
+				}(),
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: map[string]interface{}{
+				"key": "value",
+			},
+		},
+		{
+			name: "get policy cache without expired success",
+			fields: fields{
+				rolePolicies: func() gache.Gache {
+					g := gache.New()
+					g.SetWithExpire("key", "value", time.Duration(1)*time.Nanosecond)
+					// time.Sleep(time.Duration(2) * time.Nanosecond) // not working
+					time.Sleep(time.Duration(2) * time.Millisecond)
+					g.DeleteExpired(context.Background())
 					return g
 				}(),
 			},

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -2154,7 +2154,7 @@ func Test_policyd_GetPolicyCache(t *testing.T) {
 				rolePolicies: func() gache.Gache {
 					g := gache.New()
 					g.SetWithExpire("key", "value", 1*time.Nanosecond)
-					time.Sleep(100 * time.Nanosecond)
+					time.Sleep(5 * time.Millisecond)
 					g.DeleteExpired(context.Background())
 					return g
 				}(),

--- a/policy/error.go
+++ b/policy/error.go
@@ -27,8 +27,8 @@ var (
 	// ErrNoMatch "Access denied due to no match to any of the assertions defined in domain policy file"
 	ErrNoMatch = errors.New("Access denied due to no match to any of the assertions defined in domain policy file")
 
-	// ErrInvalidPolicyResource "Access denied due to invalie/empty policy resources"
-	ErrInvalidPolicyResource = errors.New("Access denied due to invalie/empty policy resources")
+	// ErrInvalidPolicyResource "Access denied due to invalid/empty policy resources"
+	ErrInvalidPolicyResource = errors.New("Access denied due to invalid/empty policy resources")
 
 	// ErrDenyByPolicy "Access Check was explicitly denied"
 	ErrDenyByPolicy = errors.New("Access Check was explicitly denied")

--- a/pubkey/daemon_test.go
+++ b/pubkey/daemon_test.go
@@ -32,7 +32,7 @@ import (
 	authcore "github.com/yahoo/athenz/libs/go/zmssvctoken"
 )
 
-func Test_pubkey_New(t *testing.T) {
+func TestNew(t *testing.T) {
 	type args struct {
 		opts []Option
 	}
@@ -106,7 +106,7 @@ func Test_pubkey_New(t *testing.T) {
 	}
 }
 
-func Test_pubkey_getPubKey(t *testing.T) {
+func Test_pubkeyd_getPubKey(t *testing.T) {
 	c := &pubkeyd{
 		confCache: &AthenzConfig{
 			ZMSPubKeys: new(sync.Map),
@@ -170,7 +170,7 @@ func Test_pubkey_getPubKey(t *testing.T) {
 	}
 }
 
-func Test_pubkey_fetchPubKeyEntries(t *testing.T) {
+func Test_pubkeyd_fetchPubKeyEntries(t *testing.T) {
 	type fields struct {
 		refreshDuration  time.Duration
 		errRetryInterval time.Duration
@@ -512,7 +512,7 @@ func Test_pubkey_fetchPubKeyEntries(t *testing.T) {
 	}
 }
 
-func Test_pubkey_GetProvider(t *testing.T) {
+func Test_pubkeyd_GetProvider(t *testing.T) {
 	c := &pubkeyd{
 		confCache: &AthenzConfig{},
 	}
@@ -536,7 +536,7 @@ func Test_pubkey_GetProvider(t *testing.T) {
 	}
 }
 
-func Test_pubkey_Update(t *testing.T) {
+func Test_pubkeyd_Update(t *testing.T) {
 	type fields struct {
 		refreshDuration  time.Duration
 		errRetryInterval time.Duration
@@ -868,7 +868,7 @@ func Test_pubkey_Update(t *testing.T) {
 	}
 }
 
-func Test_pubkey_StartpubkeyUpdator(t *testing.T) {
+func Test_pubkeyd_StartpubkeyUpdator(t *testing.T) {
 	type fields struct {
 		refreshDuration  time.Duration
 		errRetryInterval time.Duration


### PR DESCRIPTION
I tried to split the changes by commit. It maybe easier to review by commit.

@kpango 
1. The line 2157 only can pass on `go test -race`. Do you have any idea?
https://github.com/yahoojapan/athenz-authorizer/blob/2d6bbdef41652476108349d41c8439e444d0777b/policy/daemon_test.go#L2157-L2158

2. seems the retry interval is missing in jwkd: https://github.com/yahoojapan/athenz-authorizer/commit/6c79437ff203aad80ef35a9d40cdeaaffcf7b4da

3. the `ebuf` will also wrap previous error. Is this expected?
https://github.com/yahoojapan/athenz-authorizer/blob/6c79437ff203aad80ef35a9d40cdeaaffcf7b4da/jwk/daemon.go#L86-L87