### PR TITLE
[patch] Fix multi policy check logic

### DIFF
--- a/policy/daemon.go
+++ b/policy/daemon.go
@@ -45,24 +45,26 @@ type Daemon interface {
 }
 
 type policyd struct {
-	expireMargin          time.Duration // expire margin force update policy when the policy expire time hit the margin
-	rolePolicies          gache.Gache   //*sync.Map // map[<domain>:role.<role>][]Assertion
+	expireMargin time.Duration // expire margin force update policy when the policy expire time hit the margin
+
+	// The rolePolicies map has the format of  map[<domain>:role.<role>][]*Assertion
+	// The []*Assertion contains deny policies first, and following the allow policies
+	// When CheckPolicy function called, the []*Assertion is check by order, in current implementation the deny policy is prioritize,
+	// so we need to put the deny policies in lower index.
+	rolePolicies          gache.Gache
 	policyExpiredDuration time.Duration
 
-	refreshDuration time.Duration
-	//flushDur time.Duration
+	refreshDuration  time.Duration
 	errRetryInterval time.Duration
-
-	pkp pubkey.Provider
 
 	etagCache    gache.Gache
 	etagFlushDur time.Duration
 
-	// www.athenz.com/zts/v1
 	athenzURL     string
 	athenzDomains []string
 
 	client *http.Client
+	pkp    pubkey.Provider
 }
 
 type etagCache struct {
@@ -185,6 +187,7 @@ func (p *policyd) Update(ctx context.Context) error {
 
 // CheckPolicy checks the specified request has privilege to access the resources or not.
 // If return is nil then the request is allowed, otherwise the request is rejected.
+// Only action and resource is supporting wildcard, domain and role is not supporting wildcard.
 func (p *policyd) CheckPolicy(ctx context.Context, domain string, roles []string, action, resource string) error {
 	ech := make(chan error, len(roles))
 	cctx, cancel := context.WithCancel(ctx)
@@ -218,6 +221,7 @@ func (p *policyd) CheckPolicy(ctx context.Context, domain string, roles []string
 							ch <- cctx.Err()
 							return
 						default:
+							// deny policies come first in rolePolicies, so it will return first before allow policies is checked
 							if strings.EqualFold(ass.ResourceDomain, domain) && ass.Reg.MatchString(strings.ToLower(action+"-"+resource)) {
 								ch <- ass.Effect
 								return
@@ -232,7 +236,7 @@ func (p *policyd) CheckPolicy(ctx context.Context, domain string, roles []string
 
 	allowed := false
 	for err := range ech {
-		if err != nil {
+		if err != nil { // denied assertion is prioritize, so return directly
 			return err
 		}
 		allowed = true
@@ -243,6 +247,7 @@ func (p *policyd) CheckPolicy(ctx context.Context, domain string, roles []string
 	return errors.Wrap(ErrNoMatch, "no match")
 }
 
+// GetPolicyCache returns the cached role policy data
 func (p *policyd) GetPolicyCache(ctx context.Context) map[string]interface{} {
 	return p.rolePolicies.ToRawMap(ctx)
 }
@@ -390,9 +395,9 @@ func simplifyAndCachePolicy(ctx context.Context, rp gache.Gache, sp *SignedPolic
 		if r, ok := rp.Get(ass.Role); ok {
 			asss = r.([]*Assertion)
 			if a.Effect == nil {
-				asss = append(asss, a)
+				asss = append(asss, a) // append allowed policies to the end of the slice
 			} else {
-				asss = append([]*Assertion{a}, asss...)
+				asss = append([]*Assertion{a}, asss...) // append denied policies to the head
 			}
 		} else {
 			asss = []*Assertion{a}

--- a/policy/daemon.go
+++ b/policy/daemon.go
@@ -215,6 +215,7 @@ func (p *policyd) CheckPolicy(ctx context.Context, domain string, roles []string
 						if strings.EqualFold(ass.ResourceDomain, domain) && ass.Reg.MatchString(strings.ToLower(action+"-"+resource)) {
 							if eff := ass.Effect; eff != nil {
 								ch <- ass.Effect
+								return
 							} else {
 								allowed = true
 							}

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -695,39 +695,37 @@ func Test_policyd_CheckPolicy(t *testing.T) {
 			},
 			want: errors.New("no match: Access denied due to no match to any of the assertions defined in domain policy file"),
 		},
-		/*
-			test{
-				name: "check policy deny with multiple roles with allow and deny",
-				fields: fields{
-					rolePolicies: func() gache.Gache {
-						g := gache.New()
-						for i := 0; i < 200; i++ {
-							g.Set("dummyDom:role.dummyRole", []*Assertion{
-								func() *Assertion {
-									a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "allow")
-									return a
-								}(),
-							})
-						}
-						g.Set("dummyDom:role.dummyRole1", []*Assertion{
+		{
+			name: "check policy deny with multiple roles with allow and deny",
+			fields: fields{
+				rolePolicies: func() gache.Gache {
+					g := gache.New()
+					for i := 0; i < 200; i++ {
+						g.Set("dummyDom:role.dummyRole", []*Assertion{
 							func() *Assertion {
-								a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "deny")
+								a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "allow")
 								return a
 							}(),
 						})
-						return g
-					}(),
-				},
-				args: args{
-					ctx:      context.Background(),
-					domain:   "dummyDom",
-					roles:    []string{"dummyRole", "dummyRole1"},
-					action:   "dummyAct",
-					resource: "dummyRes",
-				},
-				want: errors.New("policy deny: Access Check was explicitly denied"),
+					}
+					g.Set("dummyDom:role.dummyRole1", []*Assertion{
+						func() *Assertion {
+							a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "deny")
+							return a
+						}(),
+					})
+					return g
+				}(),
 			},
-		*/
+			args: args{
+				ctx:      context.Background(),
+				domain:   "dummyDom",
+				roles:    []string{"dummyRole", "dummyRole1"},
+				action:   "dummyAct",
+				resource: "dummyRes",
+			},
+			want: errors.New("policy deny: Access Check was explicitly denied"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -424,8 +424,8 @@ func Test_policyd_Update(t *testing.T) {
 			}))
 			srv := httptest.NewTLSServer(handler)
 
-			domains := make([]string, 1000)
-			for i := 0; i < 1000; i++ {
+			domains := make([]string, 500)
+			for i := 0; i < 500; i++ {
 				domains[i] = fmt.Sprintf("dummyDom%d", i)
 			}
 

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -730,12 +730,13 @@ func Test_policyd_CheckPolicy(t *testing.T) {
 				rolePolicies: func() gache.Gache {
 					g := gache.New()
 					asss := make([]*Assertion, 0, 200)
+					da, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "deny")
 					a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "allow")
+
+					asss = append(asss, da)
 					for i := 0; i < 199; i++ {
 						asss = append(asss, a)
 					}
-					da, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "deny")
-					asss = append(asss, da)
 					g.Set("dummyDom:role.dummyRole", asss)
 					return g
 				}(),

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -2589,6 +2589,93 @@ func Test_simplifyAndCachePolicy(t *testing.T) {
 				wantErr: false,
 			}
 		}(),
+		func() test {
+			rp := gache.New()
+			return test{
+				name: "cache deny policies sorted first",
+				args: args{
+					ctx: context.Background(),
+					rp:  rp,
+					sp: &SignedPolicy{
+						util.DomainSignedPolicyData{
+							SignedPolicyData: &util.SignedPolicyData{
+								Expires: &rdl.Timestamp{
+									Time: fastime.Now().Add(time.Hour * 99999).UTC(),
+								},
+								PolicyData: &util.PolicyData{
+									Policies: []*util.Policy{
+										{
+											Assertions: []*util.Assertion{
+												{
+													Role:     "dummyDom:role.dummyRole",
+													Action:   "dummyAct",
+													Resource: "dummyDom:dummyRes1",
+													Effect:   "allow",
+												},
+												{
+													Role:     "dummyDom:role.dummyRole",
+													Action:   "dummyAct",
+													Resource: "dummyDom:dummyRes2",
+													Effect:   "allow",
+												},
+											},
+										},
+										{
+											Assertions: []*util.Assertion{
+												{
+													Role:     "dummyDom:role.dummyRole",
+													Action:   "dummyAct",
+													Resource: "dummyDom:dummyRes3",
+													Effect:   "deny",
+												},
+											},
+										},
+										{
+											Assertions: []*util.Assertion{
+												{
+													Role:     "dummyDom:role.dummyRole",
+													Action:   "dummyAct",
+													Resource: "dummyDom:dummyRes4",
+													Effect:   "allow",
+												},
+												{
+													Role:     "dummyDom:role.dummyRole",
+													Action:   "dummyAct",
+													Resource: "dummyDom:dummyRes5",
+													Effect:   "deny",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				checkFunc: func() error {
+					if len(rp.ToRawMap(context.Background())) != 1 {
+						return errors.Errorf("invalid length role policies 1, role policies: %v", rp.ToRawMap(context.Background()))
+					}
+
+					gotRp, ok := rp.Get("dummyDom:role.dummyRole")
+					if !ok {
+						return errors.New("cannot simplify and cache data")
+					}
+					gotAsss := gotRp.([]*Assertion)
+					if len(gotAsss) == 0 {
+						return errors.Errorf("invalid length asss, got: %v", gotAsss)
+					}
+					for i, a := range gotAsss {
+						if (i <= 1 && a.Effect == nil) || (i > 1 && a.Effect != nil) {
+							return errors.Errorf("deny assertion do not come first, got: %v, %d, %v", gotAsss, i, *a)
+						}
+					}
+
+					return nil
+				},
+				wantErr: false,
+			}
+		}(),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -700,20 +700,43 @@ func Test_policyd_CheckPolicy(t *testing.T) {
 			fields: fields{
 				rolePolicies: func() gache.Gache {
 					g := gache.New()
+					asss := make([]*Assertion, 0, 200)
+					a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "allow")
 					for i := 0; i < 200; i++ {
-						g.Set("dummyDom:role.dummyRole", []*Assertion{
-							func() *Assertion {
-								a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "allow")
-								return a
-							}(),
-						})
+						asss = append(asss, a)
 					}
+					g.Set("dummyDom:role.dummyRole", asss)
 					g.Set("dummyDom:role.dummyRole1", []*Assertion{
 						func() *Assertion {
 							a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "deny")
 							return a
 						}(),
 					})
+					return g
+				}(),
+			},
+			args: args{
+				ctx:      context.Background(),
+				domain:   "dummyDom",
+				roles:    []string{"dummyRole", "dummyRole1"},
+				action:   "dummyAct",
+				resource: "dummyRes",
+			},
+			want: errors.New("policy deny: Access Check was explicitly denied"),
+		},
+		{
+			name: "check policy deny with single role with allow and deny",
+			fields: fields{
+				rolePolicies: func() gache.Gache {
+					g := gache.New()
+					asss := make([]*Assertion, 0, 200)
+					a, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "allow")
+					for i := 0; i < 199; i++ {
+						asss = append(asss, a)
+					}
+					da, _ := NewAssertion("dummyAct", "dummyDom:dummyRes", "deny")
+					asss = append(asss, da)
+					g.Set("dummyDom:role.dummyRole", asss)
 					return g
 				}(),
 			},

--- a/policy/daemon_test.go
+++ b/policy/daemon_test.go
@@ -424,8 +424,8 @@ func Test_policyd_Update(t *testing.T) {
 			}))
 			srv := httptest.NewTLSServer(handler)
 
-			domains := make([]string, 500)
-			for i := 0; i < 500; i++ {
+			domains := make([]string, 1000)
+			for i := 0; i < 1000; i++ {
 				domains[i] = fmt.Sprintf("dummyDom%d", i)
 			}
 


### PR DESCRIPTION
When `allow` and `deny` policy exists in the same resources, the deny policy will be prioritized.