### PR TITLE
propose: move token extract logic to authorizer

### DIFF
--- a/authorizerd.go
+++ b/authorizerd.go
@@ -168,12 +168,21 @@ func New(opts ...Option) (Authorizerd, error) {
 		jwkProvider = prov.jwkd.GetProvider()
 	}
 
+	// TODO: refactor the default values
+	atpParam := ATProcessorParam{
+		verifyCertThumbprint: true,
+		certBackdateDur:      "1h",
+		certOffsetDur:        "1h",
+	}
+	if len(prov.atpParams) > 0 {
+		atpParam = prov.atpParams[0]
+	}
 	if prov.roleProcessor, err = role.New(
 		role.WithPubkeyProvider(pubkeyProvider),
 		role.WithJWKProvider(jwkProvider),
-		// WithEnableMTLSCertificateBoundAccessToken ?
-		role.WithClientCertificateGoBackSeconds(prov.atpParams[0].certBackdateDur),
-		role.WithClientCertificateOffsetSeconds(prov.atpParams[0].certOffsetDur),
+		role.WithEnableMTLSCertificateBoundAccessToken(atpParam.verifyCertThumbprint),
+		role.WithClientCertificateGoBackSeconds(atpParam.certBackdateDur),
+		role.WithClientCertificateOffsetSeconds(atpParam.certOffsetDur),
 	); err != nil {
 		return nil, errors.Wrap(err, "error create role processor")
 	}

--- a/authorizerd.go
+++ b/authorizerd.go
@@ -218,7 +218,7 @@ func (a *authorizer) initVerifiers() error {
 	}
 
 	// resize
-	a.verifiers = append([]verifier(nil), verifiers[:len(verifiers)]...)
+	a.verifiers = append([]verifier(nil), verifiers...)
 	return nil
 }
 

--- a/errors.go
+++ b/errors.go
@@ -46,6 +46,9 @@ var (
 
 	// ErrInvalidParameters "Access denied due to invalid/empty action/resource values"
 	ErrInvalidParameters = errors.New("Access denied due to invalid/empty action/resource values")
+
+	// ErrInvalidCredentials "Access denied due to invalid credentials"
+	ErrInvalidCredentials = errors.New("Access denied due to invalid credentials")
 )
 
 /*

--- a/option.go
+++ b/option.go
@@ -35,11 +35,23 @@ var (
 		WithPolicyErrRetryInterval("1m"),
 		WithPubkeyErrRetryInterval("1m"),
 		WithJwkErrRetryInterval("1m"),
-		WithATEnableMTLSCertificateBoundAccessToken(true),
-		WithATProcessorClientCertificateGoBackSeconds("1h"),
-		WithATProcessorClientCertificateOffsetSeconds("1h"),
+		WithNewATProcessorParam(ATProcessorParam{
+			verifyAccessToken:                       true,
+			enableMTLSCertificateBoundAccessToken:   true,
+			processorClientCertificateGoBackSeconds: "1h",
+			processorClientCertificateOffsetSeconds: "1h",
+		}),
+		WithRTVerifyRoleToken(true),
+		WithRCVerifyRoleCert(true),
 	}
 )
+
+type ATProcessorParam struct {
+	verifyAccessToken                       bool
+	enableMTLSCertificateBoundAccessToken   bool
+	processorClientCertificateGoBackSeconds string
+	processorClientCertificateOffsetSeconds string
+}
 
 // Option represents a functional option
 type Option func(*authorizer) error
@@ -241,26 +253,42 @@ func WithJwkErrRetryInterval(i string) Option {
 	access token parameters
 */
 
-// WithATEnableMTLSCertificateBoundAccessToken returns a EnableMTLSCertificateBoundAccessToken functional option
-func WithATEnableMTLSCertificateBoundAccessToken(b bool) Option {
+// WithNewATProcessor returns a functional option that appends the new access token processor parameters
+func WithNewATProcessorParam(atpParam ATProcessorParam) Option {
 	return func(authz *authorizer) error {
-		authz.enableMTLSCertificateBoundAccessToken = b
+		authz.atpParams = append(authz.atpParams, atpParam)
 		return nil
 	}
 }
 
-// WithATProcessorClientCertificateGoBackSeconds returns a ProcessorClientCertificateGoBackSeconds functional option
-func WithATProcessorClientCertificateGoBackSeconds(t string) Option {
+/*
+	role token parameters
+*/
+
+// WithRTVerifyRoleToken returns a VerifyRoleToken functional option
+func WithRTVerifyRoleToken(b bool) Option {
 	return func(authz *authorizer) error {
-		authz.processorClientCertificateGoBackSeconds = t
+		authz.verifyRoleToken = b
 		return nil
 	}
 }
 
-// WithATProcessorClientCertificateOffsetSeconds returns a ProcessorClientCertificateOffsetSeconds functional option
-func WithATProcessorClientCertificateOffsetSeconds(t string) Option {
+// WithRTHeader returns a RTHeader functional option
+func WithRTHeader(h string) Option {
 	return func(authz *authorizer) error {
-		authz.processorClientCertificateOffsetSeconds = t
+		authz.rtHeader = h
+		return nil
+	}
+}
+
+/*
+	role certificate parameters
+*/
+
+// WithRCVerifyRoleCert returns a VerifyRoleCert functional option
+func WithRCVerifyRoleCert(b bool) Option {
+	return func(authz *authorizer) error {
+		authz.verifyRoleCert = b
 		return nil
 	}
 }

--- a/option.go
+++ b/option.go
@@ -35,22 +35,16 @@ var (
 		WithPolicyErrRetryInterval("1m"),
 		WithPubkeyErrRetryInterval("1m"),
 		WithJwkErrRetryInterval("1m"),
-		WithNewATProcessorParam(ATProcessorParam{
-			verifyAccessToken:                       true,
-			enableMTLSCertificateBoundAccessToken:   true,
-			processorClientCertificateGoBackSeconds: "1h",
-			processorClientCertificateOffsetSeconds: "1h",
-		}),
+		// WithNewATProcessorParam(true, "1h", "1h"), // TODO: design how to have default, user cannot overwrite this one
 		WithRTVerifyRoleToken(true),
 		WithRCVerifyRoleCert(true),
 	}
 )
 
 type ATProcessorParam struct {
-	verifyAccessToken                       bool
-	enableMTLSCertificateBoundAccessToken   bool
-	processorClientCertificateGoBackSeconds string
-	processorClientCertificateOffsetSeconds string
+	verifyCertThumbprint bool
+	certBackdateDur      string
+	certOffsetDur        string
 }
 
 // Option represents a functional option
@@ -254,9 +248,13 @@ func WithJwkErrRetryInterval(i string) Option {
 */
 
 // WithNewATProcessor returns a functional option that appends the new access token processor parameters
-func WithNewATProcessorParam(atpParam ATProcessorParam) Option {
+func WithNewATProcessorParam(verifyCertThumbprint bool, certBackdateDur, certOffsetDur string) Option {
 	return func(authz *authorizer) error {
-		authz.atpParams = append(authz.atpParams, atpParam)
+		authz.atpParams = append(authz.atpParams, ATProcessorParam{
+			verifyCertThumbprint: verifyCertThumbprint,
+			certBackdateDur:      certBackdateDur,
+			certOffsetDur:        certOffsetDur,
+		})
 		return nil
 	}
 }

--- a/role/processor.go
+++ b/role/processor.go
@@ -189,7 +189,7 @@ func (r *rtp) validateCertPrincipal(cert *x509.Certificate, claims *ZTSAccessTok
 	if cert.NotBefore.Unix() < claims.IssuedAt-r.clientCertificateGoBackSeconds {
 		return errors.Errorf("error certificate: %v issued before token: %v", cert.NotBefore.Unix(), claims.IssuedAt)
 	}
-	// Issue tiem check. Determine if certificate's issue time is within an allowed range
+	// Issue time check. Determine if certificate's issue time is within an allowed range
 	if cert.NotBefore.Unix() > claims.IssuedAt+r.clientCertificateOffsetSeconds-r.clientCertificateGoBackSeconds {
 		return errors.Errorf("Certificate: %v past configured offset %v for token: %v", cert.NotBefore.Unix(), r.clientCertificateOffsetSeconds, claims.IssuedAt)
 	}


### PR DESCRIPTION
1. add enable flags, speed up with the verifier array
1. extract logic on authorizer, not proxy

`Proxy.RoleHeader` should be in `Authorization`
https://github.com/yahoojapan/authorization-proxy/blob/96cf458bec02d6a22b9a1c07169ed664e508b223/config/config.go#L122-L123

only have cfg.Proxy
https://github.com/yahoojapan/authorization-proxy/blob/96cf458bec02d6a22b9a1c07169ed664e508b223/handler/transport.go#L37-L54