### PR TITLE
[minor] Support role name in CN

### DIFF
--- a/authorizerd.go
+++ b/authorizerd.go
@@ -113,6 +113,7 @@ type mode uint8
 
 const (
 	cacheKeyDelimiter      = ':'
+	roleInCNDelimiter      = ":role."
 	roleToken         mode = iota
 	accessToken
 )
@@ -497,7 +498,7 @@ func (a *authority) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certif
 
 	for _, cert := range peerCerts {
 		subj := cert.Subject.CommonName
-		dr := strings.SplitN(subj, ":role.", 2)
+		dr := strings.SplitN(subj, roleInCNDelimiter, 2)
 		// dr will be just ignored when subj doesn't represents a role (not contains ":role.")
 		addDomainRoles(dr)
 

--- a/authorizerd.go
+++ b/authorizerd.go
@@ -481,22 +481,31 @@ func (a *authority) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certif
 		return nil
 	}
 
-	var dr []string
 	drcheck := make(map[string]struct{})
 	domainRoles := make(map[string][]string)
+	addDomainRoles := func(dr []string) {
+		if len(dr) != 2 {
+			return
+		}
+		domain, roleName := dr[0], dr[1]
+		// duplicated role check
+		if _, ok := drcheck[domain+roleName]; !ok {
+			domainRoles[domain] = append(domainRoles[domain], roleName)
+			drcheck[domain+roleName] = struct{}{}
+		}
+	}
+
 	for _, cert := range peerCerts {
+		// TODO: check issuer (like certIssuerMatch in AuthZpeClient.allowAccess does)
+		subj := cert.Subject.CommonName
+		dr := strings.SplitN(subj, ":role.", 2)
+		// dr will be just ignored when subj doesn't represents a role (not contains ":role.")
+		addDomainRoles(dr)
+
 		for _, uri := range cert.URIs {
 			if strings.HasPrefix(uri.String(), a.roleCertURIPrefix) {
-				dr = strings.SplitN(strings.TrimPrefix(uri.String(), a.roleCertURIPrefix), "/", 2) // domain/role
-				if len(dr) != 2 {
-					continue
-				}
-				domain, roleName := dr[0], dr[1]
-				// duplicated role check
-				if _, ok := drcheck[domain+roleName]; !ok {
-					domainRoles[domain] = append(domainRoles[domain], roleName)
-					drcheck[domain+roleName] = struct{}{}
-				}
+				dr := strings.SplitN(strings.TrimPrefix(uri.String(), a.roleCertURIPrefix), "/", 2) // domain/role
+				addDomainRoles(dr)
 			}
 		}
 	}

--- a/authorizerd.go
+++ b/authorizerd.go
@@ -496,7 +496,6 @@ func (a *authority) VerifyRoleCert(ctx context.Context, peerCerts []*x509.Certif
 	}
 
 	for _, cert := range peerCerts {
-		// TODO: check issuer (like certIssuerMatch in AuthZpeClient.allowAccess does)
 		subj := cert.Subject.CommonName
 		dr := strings.SplitN(subj, ":role.", 2)
 		// dr will be just ignored when subj doesn't represents a role (not contains ":role.")


### PR DESCRIPTION
# Description

This PR adds a new behavior on extracting role name from RoleCertificate.
If the CommonName in the certificate is in the format of `<domain>:role.<role>`, it will also recognize as a role name.

Currently, role names from CN and SANs are combined as extracted roles. I'm not sure it is ok or it should be handled exclusively. Which means, when the CN appears to be a role name, SANs should be ignored or not.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

## Related issue/PR
- Fixes #82

---

## Checklist

- [ ] Followed the guidelines in the CONTRIBUTING document
- [X] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/athenz-authorizer/pulls))
- [x] Passed all pipeline checking
- [ ] Approved by >1 reviewer

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [ ] Delete the branch after merge
