### PR TITLE
[skip] fix corrupted version with nightly tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
             fi
             printf 'LAST_COMMIT: %s\n' "${LAST_COMMIT}"
             touch ./.tag
-            VERSION="$(git describe --abbrev=0 --tags)"
+            VERSION="$(git tag -l --sort=-creatordate 'v*' | head -n 1)"
             # Diff to prevent pipeline re-runs.
             if [ -n "$(git diff "$VERSION")" ]; then
               VERSION=${VERSION:-'v0.0.0'}


### PR DESCRIPTION
# Description

same as: https://github.com/yahoojapan/athenz-client-sidecar/pull/54

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/athenz-authorizer/pulls))
- [x] Passed all pipeline checking
- [ ] Approved by >1 reviewer

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [ ] Delete the branch after merge
