### PR TITLE
[minor] add proxy-principals feature support

### DIFF
--- a/access/claim.go
+++ b/access/claim.go
@@ -58,12 +58,12 @@ func (c *BaseClaim) Valid() error {
 // OAuth2AccessTokenClaim represents access token claim data.
 // based on https://github.com/AthenZ/athenz/blob/0e7335dbfa9d41eef0b049c07e7f846bff0f3169/libs/java/auth_core/src/main/java/com/AthenZ/athenz/auth/token/AccessToken.java#L382
 type OAuth2AccessTokenClaim struct {
-	AuthTime       int64             `json:"auth_time"`
-	Version        int               `json:"ver"`
-	ClientID       string            `json:"client_id"`
-	UserID         string            `json:"uid"`
-	ProxyPrincipal string            `json:"proxy,omitempty"`
-	Scope          []string          `json:"scp"`
-	Confirm        map[string]string `json:"cnf"`
+	AuthTime       int64          `json:"auth_time"`
+	Version        int            `json:"ver"`
+	ClientID       string         `json:"client_id"`
+	UserID         string         `json:"uid"`
+	ProxyPrincipal string         `json:"proxy,omitempty"`
+	Scope          []string       `json:"scp"`
+	Confirm        map[string]any `json:"cnf"`
 	BaseClaim
 }

--- a/access/claim.go
+++ b/access/claim.go
@@ -56,7 +56,7 @@ func (c *BaseClaim) Valid() error {
 }
 
 // OAuth2AccessTokenClaim represents access token claim data.
-// based on https://github.com/AthenZ/athenz/blob/0e7335dbfa9d41eef0b049c07e7f846bff0f3169/libs/java/auth_core/src/main/java/com/AthenZ/athenz/auth/token/AccessToken.java#L382
+// based on https://github.com/AthenZ/athenz/blob/e85e233555247f2a4239bf302825e1bbf9493af9/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/AccessToken.java#L468-L476
 type OAuth2AccessTokenClaim struct {
 	AuthTime       int64                  `json:"auth_time"`
 	Version        int                    `json:"ver"`

--- a/access/claim.go
+++ b/access/claim.go
@@ -58,12 +58,12 @@ func (c *BaseClaim) Valid() error {
 // OAuth2AccessTokenClaim represents access token claim data.
 // based on https://github.com/AthenZ/athenz/blob/0e7335dbfa9d41eef0b049c07e7f846bff0f3169/libs/java/auth_core/src/main/java/com/AthenZ/athenz/auth/token/AccessToken.java#L382
 type OAuth2AccessTokenClaim struct {
-	AuthTime       int64          `json:"auth_time"`
-	Version        int            `json:"ver"`
-	ClientID       string         `json:"client_id"`
-	UserID         string         `json:"uid"`
-	ProxyPrincipal string         `json:"proxy,omitempty"`
-	Scope          []string       `json:"scp"`
-	Confirm        map[string]any `json:"cnf"`
+	AuthTime       int64                  `json:"auth_time"`
+	Version        int                    `json:"ver"`
+	ClientID       string                 `json:"client_id"`
+	UserID         string                 `json:"uid"`
+	ProxyPrincipal string                 `json:"proxy,omitempty"`
+	Scope          []string               `json:"scp"`
+	Confirm        map[string]interface{} `json:"cnf"`
 	BaseClaim
 }

--- a/access/processor.go
+++ b/access/processor.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"log"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/lestrrat-go/jwx/jws"
@@ -28,7 +29,8 @@ import (
 )
 
 const (
-	confirmMethodMember = "x5t#S256"
+	confirmMethodCertThumbprint  = "x5t#S256"
+	confirmMethodProxyPrincipals = "proxy-principals#spiffe"
 )
 
 // errNilHeader is "header is nil"
@@ -125,25 +127,36 @@ func (a *atp) validateCertificateBoundAccessToken(cert *x509.Certificate, claims
 		return errors.New("error claim of access token is nil")
 	}
 
-	certThumbprint, ok := claims.Confirm[confirmMethodMember]
-	if !ok {
-		return errors.New("error token is not certificate bound access token")
+	if certThumbprint, ok := claims.Confirm[confirmMethodCertThumbprint].(string); ok {
+		log.Print(certThumbprint)
+		// cnf check
+		sum := sha256.Sum256(cert.Raw)
+		if base64.RawURLEncoding.EncodeToString(sum[:]) == certThumbprint {
+			return nil
+		}
+
+		// If cnf check fails, check to allow if the certificate has been refresh
+		if err := a.validateCertPrincipal(cert, claims); err == nil {
+			return nil
+		}
 	}
 
-	// cnf check
-	sum := sha256.Sum256(cert.Raw)
-	if base64.RawURLEncoding.EncodeToString(sum[:]) == certThumbprint {
-		return nil
+	// validate the proxy principal.
+	if proxyPrincipals, ok := claims.Confirm[confirmMethodProxyPrincipals].([]any); ok {
+		valid := make(map[string]struct{}, len(proxyPrincipals))
+		for _, value := range proxyPrincipals {
+			if spiffe, ok := value.(string); ok {
+				valid[spiffe] = struct{}{}
+			}
+		}
+		for _, uri := range cert.URIs {
+			if _, ok := valid[uri.String()]; ok {
+				return nil
+			}
+		}
 	}
 
-	// If cnf check fails, check to allow if the certificate has been refresh
-	if err := a.validateCertPrincipal(cert, claims); err != nil {
-		return err
-	}
-
-	// auth_core is validating the proxy principal here.(future work)
-
-	return nil
+	return errors.New("error certificate: no valid bound for the certificate to access token")
 }
 
 func (a *atp) validateCertPrincipal(cert *x509.Certificate, claims *OAuth2AccessTokenClaim) error {

--- a/access/processor.go
+++ b/access/processor.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
-	"log"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/lestrrat-go/jwx/jws"
@@ -128,7 +127,6 @@ func (a *atp) validateCertificateBoundAccessToken(cert *x509.Certificate, claims
 	}
 
 	if certThumbprint, ok := claims.Confirm[confirmMethodCertThumbprint].(string); ok {
-		log.Print(certThumbprint)
 		// cnf check
 		sum := sha256.Sum256(cert.Raw)
 		if base64.RawURLEncoding.EncodeToString(sum[:]) == certThumbprint {

--- a/access/processor.go
+++ b/access/processor.go
@@ -142,7 +142,7 @@ func (a *atp) validateCertificateBoundAccessToken(cert *x509.Certificate, claims
 	}
 
 	// validate the proxy principal.
-	if proxyPrincipals, ok := claims.Confirm[confirmMethodProxyPrincipals].([]any); ok {
+	if proxyPrincipals, ok := claims.Confirm[confirmMethodProxyPrincipals].([]interface{}); ok {
 		valid := make(map[string]struct{}, len(proxyPrincipals))
 		for _, value := range proxyPrincipals {
 			if spiffe, ok := value.(string); ok {

--- a/access/processor_test.go
+++ b/access/processor_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"io/ioutil"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -402,7 +403,7 @@ func Test_rtp_ParseAndValidateOAuth2AccessToken(t *testing.T) {
 						ClientID: "domain.tenant.service",
 						UserID:   "domain.tenant.service",
 						Scope:    []string{"admin", "user"},
-						Confirm:  map[string]string{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+						Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
 					}
 					return &c
 				}(),
@@ -820,7 +821,7 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]string{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+					Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
 				},
 			},
 			wantErr: false,
@@ -855,7 +856,56 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]string{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+					Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "verify certificate bound access token success, proxy-principals certificate",
+			fields: fields{
+				enableMTLSCertificateBoundAccessToken: true,
+				clientCertificateOffsetSeconds:        3600,
+			},
+			args: args{
+				cert: &x509.Certificate{
+					KeyUsage: x509.KeyUsageDigitalSignature,
+					Subject: pkix.Name{
+						CommonName: "domain.tenant.service",
+					},
+					URIs: []*url.URL{
+						func() *url.URL {
+							u, err := url.Parse("spiffe://domain/sa/service")
+							if err != nil {
+								t.Fatal(err)
+							}
+							return u
+						}(),
+					},
+					NotBefore: time.Unix(1585122381+100, 0), // token's IssuedAt + 100
+					NotAfter:  time.Unix(9999999999, 0),
+				},
+				claims: &OAuth2AccessTokenClaim{
+					BaseClaim: BaseClaim{
+						StandardClaims: jwt.StandardClaims{
+							Subject:   "domain.tenant.service",
+							IssuedAt:  1585122381,
+							ExpiresAt: 9999999999,
+							Issuer:    "https://zts.athenz.io",
+							Audience:  "domain.provider",
+						},
+					},
+					AuthTime: 1585122381,
+					Version:  1,
+					ClientID: "domain.tenant.service",
+					UserID:   "domain.tenant.service",
+					Scope:    []string{"admin", "user"},
+					Confirm: map[string]any{
+						"x5t#S256": "invalid",
+						"proxy-principals#spiffe": []any{
+							"spiffe://domain/sa/service",
+						},
+					},
 				},
 			},
 			wantErr: false,
@@ -882,7 +932,7 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]string{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+					Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
 				},
 			},
 			wantErr: true,
@@ -922,7 +972,7 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]string{"x5t#S256": "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo"},
+					Confirm:  map[string]any{"x5t#S256": "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo"},
 				},
 			},
 			wantErr: true,
@@ -983,7 +1033,12 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					Version:  1,
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]string{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+					Confirm: map[string]any{
+						"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4",
+						"proxy-principals#spiffe": []any{
+							"spiffe://domain/sa/service",
+						},
+					},
 				},
 			},
 			wantErr: true,
@@ -1047,7 +1102,7 @@ func Test_rtp_validateCertPrincipal(t *testing.T) {
 						},
 					},
 					ClientID: "domain.tenant.service",
-					Confirm:  map[string]string{"x5t#S256": "dummy"},
+					Confirm:  map[string]any{"x5t#S256": "dummy"},
 				},
 			},
 		},
@@ -1077,7 +1132,7 @@ func Test_rtp_validateCertPrincipal(t *testing.T) {
 						},
 					},
 					ClientID: "domain.tenant.service",
-					Confirm:  map[string]string{"x5t#S256": "dummy"},
+					Confirm:  map[string]any{"x5t#S256": "dummy"},
 				},
 			},
 		},
@@ -1104,7 +1159,7 @@ func Test_rtp_validateCertPrincipal(t *testing.T) {
 						},
 					},
 					ClientID: "domain.tenant.service",
-					Confirm:  map[string]string{"x5t#S256": "dummy"},
+					Confirm:  map[string]any{"x5t#S256": "dummy"},
 				},
 			},
 			wantErr: true,

--- a/access/processor_test.go
+++ b/access/processor_test.go
@@ -403,7 +403,7 @@ func Test_rtp_ParseAndValidateOAuth2AccessToken(t *testing.T) {
 						ClientID: "domain.tenant.service",
 						UserID:   "domain.tenant.service",
 						Scope:    []string{"admin", "user"},
-						Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+						Confirm:  map[string]interface{}{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
 					}
 					return &c
 				}(),
@@ -821,7 +821,7 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+					Confirm:  map[string]interface{}{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
 				},
 			},
 			wantErr: false,
@@ -856,7 +856,7 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+					Confirm:  map[string]interface{}{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
 				},
 			},
 			wantErr: false,
@@ -900,9 +900,9 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm: map[string]any{
+					Confirm: map[string]interface{}{
 						"x5t#S256": "invalid",
-						"proxy-principals#spiffe": []any{
+						"proxy-principals#spiffe": []interface{}{
 							"spiffe://domain/sa/service",
 						},
 					},
@@ -932,7 +932,7 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]any{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
+					Confirm:  map[string]interface{}{"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4"},
 				},
 			},
 			wantErr: true,
@@ -972,7 +972,7 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					ClientID: "domain.tenant.service",
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm:  map[string]any{"x5t#S256": "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo"},
+					Confirm:  map[string]interface{}{"x5t#S256": "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo"},
 				},
 			},
 			wantErr: true,
@@ -1033,9 +1033,9 @@ func Test_rtp_validateCertificateBoundAccessToken(t *testing.T) {
 					Version:  1,
 					UserID:   "domain.tenant.service",
 					Scope:    []string{"admin", "user"},
-					Confirm: map[string]any{
+					Confirm: map[string]interface{}{
 						"x5t#S256": "2jt82f2uM8jE2LMcb4erhhTc-uy1yB1iEyp5MnI5uF4",
-						"proxy-principals#spiffe": []any{
+						"proxy-principals#spiffe": []interface{}{
 							"spiffe://domain/sa/service",
 						},
 					},
@@ -1102,7 +1102,7 @@ func Test_rtp_validateCertPrincipal(t *testing.T) {
 						},
 					},
 					ClientID: "domain.tenant.service",
-					Confirm:  map[string]any{"x5t#S256": "dummy"},
+					Confirm:  map[string]interface{}{"x5t#S256": "dummy"},
 				},
 			},
 		},
@@ -1132,7 +1132,7 @@ func Test_rtp_validateCertPrincipal(t *testing.T) {
 						},
 					},
 					ClientID: "domain.tenant.service",
-					Confirm:  map[string]any{"x5t#S256": "dummy"},
+					Confirm:  map[string]interface{}{"x5t#S256": "dummy"},
 				},
 			},
 		},
@@ -1159,7 +1159,7 @@ func Test_rtp_validateCertPrincipal(t *testing.T) {
 						},
 					},
 					ClientID: "domain.tenant.service",
-					Confirm:  map[string]any{"x5t#S256": "dummy"},
+					Confirm:  map[string]interface{}{"x5t#S256": "dummy"},
 				},
 			},
 			wantErr: true,


### PR DESCRIPTION
# Description

Ref: https://github.com/yahoojapan/athenz-authorizer/issues/57

We need a feature to authorize a "proxied" access token. The authorized proxy principal is expected to store in claims in `[]string` format with key `proxy-principals#spiffe`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

## Related issue/PR

- Fixes #57

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/athenz-authorizer/pulls))
- [x] Passed all pipeline checking
- [x] Approved by >1 reviewer

## Checklist for maintainer
- [x] Use `Squash and merge`
- [x] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [x] Delete the branch after merge
